### PR TITLE
Replace window.confirm with custom modal

### DIFF
--- a/src/app/budget/page.tsx
+++ b/src/app/budget/page.tsx
@@ -5,6 +5,7 @@ import Layout from '@/components/Layout';
 import { useBudget } from '@/lib/api';
 import { IBudgetItem } from '@/models/BudgetItem';
 import { BudgetItemModal } from '@/components/modals';
+import ConfirmationModal from '@/components/ConfirmationModal';
 
 const BudgetPage = () => {
   // Define a type for budget items with MongoDB _id
@@ -27,6 +28,7 @@ const BudgetPage = () => {
   const [currentBudgetItem, setCurrentBudgetItem] = useState<
     BudgetItemWithId | undefined
   >(undefined);
+  const [itemToDelete, setItemToDelete] = useState<string | null>(null);
   const handleBudgetItemSubmit = async (
     budgetItemData: Partial<IBudgetItem>,
   ) => {
@@ -133,15 +135,7 @@ const BudgetPage = () => {
                     </button>
                     <button
                       className="text-red-400 hover:text-red-300"
-                      onClick={() => {
-                        if (
-                          window.confirm(
-                            'Are you sure you want to delete this budget item?',
-                          )
-                        ) {
-                          deleteBudgetItem(item._id);
-                        }
-                      }}
+                      onClick={() => setItemToDelete(item._id)}
                     >
                       Delete
                     </button>
@@ -214,6 +208,18 @@ const BudgetPage = () => {
           onClose={() => setIsModalOpen(false)}
           budgetItem={currentBudgetItem}
           onSubmit={handleBudgetItemSubmit}
+        />
+        <ConfirmationModal
+          isOpen={itemToDelete !== null}
+          onClose={() => setItemToDelete(null)}
+          onConfirm={() => {
+            if (itemToDelete) {
+              deleteBudgetItem(itemToDelete);
+            }
+          }}
+          title="Delete Budget Item"
+          message="Are you sure you want to delete this budget item?"
+          confirmText="Delete"
         />
       </div>
     </Layout>

--- a/src/app/checklist/page.tsx
+++ b/src/app/checklist/page.tsx
@@ -5,6 +5,7 @@ import Layout from '@/components/Layout';
 import { useChecklist } from '@/lib/api';
 import { IChecklist } from '@/models/ChecklistItem';
 import { ChecklistTaskModal } from '@/components/modals';
+import ConfirmationModal from '@/components/ConfirmationModal';
 import { useSession } from 'next-auth/react';
 
 // Define a local interface that modifies IChecklist to have _id as optional
@@ -43,6 +44,7 @@ const ChecklistPage = () => {
   const [currentTask, setCurrentTask] = useState<
     ChecklistItemWithId | undefined
   >(undefined);
+  const [taskToDelete, setTaskToDelete] = useState<string | null>(null);
 
   // Helper function to determine if a task was assigned to the current user
   const isAssignedToMe = (task: ChecklistItemWithId) => {
@@ -67,6 +69,15 @@ const ChecklistPage = () => {
     } catch (error) {
       console.error('Error submitting task:', error);
       // You could set an error state here to show to the user
+    }
+  };
+
+  const confirmDeleteTask = async () => {
+    if (!taskToDelete) return;
+    try {
+      await deleteTask(taskToDelete);
+    } finally {
+      setTaskToDelete(null);
     }
   };
   return (
@@ -363,16 +374,7 @@ const ChecklistPage = () => {
                                       <button
                                         className="bg-red-700 hover:bg-red-600 text-red-100 p-1.5 rounded-full text-xs transition-all transform hover:scale-110 hover:shadow-sm border border-red-500"
                                         aria-label="Delete task"
-                                        onClick={() => {
-                                          if (
-                                            task._id &&
-                                            window.confirm(
-                                              'Are you sure you want to delete this task?',
-                                            )
-                                          ) {
-                                            deleteTask(task._id);
-                                          }
-                                        }}
+                                        onClick={() => setTaskToDelete(task._id ?? null)}
                                       >
                                         <svg
                                           xmlns="http://www.w3.org/2000/svg"
@@ -523,16 +525,7 @@ const ChecklistPage = () => {
                               <button
                                 className="bg-red-700 hover:bg-red-600 text-red-100 p-1.5 rounded-full text-xs transition-all transform hover:scale-110 hover:shadow-sm border border-red-500"
                                 aria-label="Delete task"
-                                onClick={() => {
-                                  if (
-                                    task._id &&
-                                    window.confirm(
-                                      'Are you sure you want to delete this task?',
-                                    )
-                                  ) {
-                                    deleteTask(task._id);
-                                  }
-                                }}
+                                onClick={() => setTaskToDelete(task._id ?? null)}
                               >
                                 <svg
                                   xmlns="http://www.w3.org/2000/svg"
@@ -711,16 +704,7 @@ const ChecklistPage = () => {
                                     <button
                                       className="bg-gray-300 hover:bg-gray-400 text-gray-600 p-1.5 rounded-full text-xs transition-all"
                                       aria-label="Delete task"
-                                      onClick={() => {
-                                        if (
-                                          task._id &&
-                                          window.confirm(
-                                            'Are you sure you want to delete this task?',
-                                          )
-                                        ) {
-                                          deleteTask(task._id);
-                                        }
-                                      }}
+                                      onClick={() => setTaskToDelete(task._id ?? null)}
                                     >
                                       <svg
                                         xmlns="http://www.w3.org/2000/svg"
@@ -754,6 +738,14 @@ const ChecklistPage = () => {
           onClose={() => setIsModalOpen(false)}
           task={currentTask}
           onSubmit={handleTaskSubmit}
+        />
+        <ConfirmationModal
+          isOpen={taskToDelete !== null}
+          onClose={() => setTaskToDelete(null)}
+          onConfirm={confirmDeleteTask}
+          title="Delete Task"
+          message="Are you sure you want to delete this task?"
+          confirmText="Delete"
         />
       </div>
     </Layout>

--- a/src/app/guests/page.tsx
+++ b/src/app/guests/page.tsx
@@ -5,6 +5,7 @@ import { logger } from '@/lib/logger';
 import Layout from '@/components/Layout';
 import { useGuests } from '@/lib/api';
 import { GuestModal } from '@/components/modals';
+import ConfirmationModal from '@/components/ConfirmationModal';
 import { IGuest } from '@/models/Guest';
 
 // RSVP Status Badge component
@@ -40,6 +41,7 @@ const GuestsPage = () => {
     undefined,
   );
   const [isDeleting, setIsDeleting] = useState<string | null>(null);
+  const [guestToDelete, setGuestToDelete] = useState<string | null>(null);
 
   const handleGuestSubmit = async (guestData: Partial<IGuest>) => {
     try {
@@ -62,20 +64,22 @@ const GuestsPage = () => {
       // You could set an error state here to show to the user
     }
   };
-  const handleDeleteGuest = async (id?: string) => {
+  const handleDeleteGuest = (id?: string) => {
     if (!id) return;
+    setGuestToDelete(id);
+  };
 
-    if (window.confirm('Are you sure you want to delete this guest?')) {
-      try {
-        setIsDeleting(id);
-        await deleteGuest(id);
-        logger.info('Guest deleted successfully');
-      } catch (error) {
-        console.error('Error deleting guest:', error);
-        // You could set an error state here to show to the user
-      } finally {
-        setIsDeleting(null);
-      }
+  const confirmDeleteGuest = async () => {
+    if (!guestToDelete) return;
+    try {
+      setIsDeleting(guestToDelete);
+      await deleteGuest(guestToDelete);
+      logger.info('Guest deleted successfully');
+    } catch (error) {
+      console.error('Error deleting guest:', error);
+    } finally {
+      setIsDeleting(null);
+      setGuestToDelete(null);
     }
   };
 
@@ -357,6 +361,14 @@ const GuestsPage = () => {
           onClose={() => setIsModalOpen(false)}
           guest={currentGuest}
           onSubmit={handleGuestSubmit}
+        />
+        <ConfirmationModal
+          isOpen={guestToDelete !== null}
+          onClose={() => setGuestToDelete(null)}
+          onConfirm={confirmDeleteGuest}
+          title="Delete Guest"
+          message="Are you sure you want to delete this guest?"
+          confirmText="Delete"
         />
       </div>
     </Layout>

--- a/src/app/vendors/page.tsx
+++ b/src/app/vendors/page.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 import Layout from '@/components/Layout';
 import { IVendor } from '@/models/Vendor';
 import { VendorModal } from '@/components/modals';
+import ConfirmationModal from '@/components/ConfirmationModal';
 import { useVendors } from '@/lib/api';
 
 const VendorsPage = () => {
@@ -13,6 +14,7 @@ const VendorsPage = () => {
   const [currentVendor, setCurrentVendor] = useState<IVendor | undefined>(
     undefined,
   );
+  const [vendorToDelete, setVendorToDelete] = useState<string | null>(null);
   // Define a type for vendors with MongoDB _id
   type VendorWithId = IVendor & {
     _id: string;
@@ -246,15 +248,7 @@ const VendorsPage = () => {
               </button>
               <button
                 className="bg-teal-800 hover:bg-teal-700 text-teal-100 px-3 py-2 rounded-md text-sm transition-colors flex-1 flex items-center justify-center border border-teal-500"
-                onClick={() => {
-                  const vendorId = vendor._id?.toString();
-                  if (
-                    vendorId &&
-                    confirm('Are you sure you want to delete this vendor?')
-                  ) {
-                    deleteVendor(vendorId);
-                  }
-                }}
+                onClick={() => setVendorToDelete(vendor._id?.toString() || null)}
               >
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
@@ -312,6 +306,18 @@ const VendorsPage = () => {
           onClose={() => setIsModalOpen(false)}
           vendor={currentVendor}
           onSubmit={handleVendorSubmit}
+        />
+        <ConfirmationModal
+          isOpen={vendorToDelete !== null}
+          onClose={() => setVendorToDelete(null)}
+          onConfirm={() => {
+            if (vendorToDelete) {
+              deleteVendor(vendorToDelete);
+            }
+          }}
+          title="Delete Vendor"
+          message="Are you sure you want to delete this vendor?"
+          confirmText="Delete"
         />
       </div>
     </Layout>

--- a/src/components/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import Modal from './Modal';
+import { FormButton } from './FormElements';
+
+interface ConfirmationModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  title?: string;
+  message: string;
+  confirmText?: string;
+  cancelText?: string;
+}
+
+const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
+  isOpen,
+  onClose,
+  onConfirm,
+  title = 'Confirm Action',
+  message,
+  confirmText = 'Confirm',
+  cancelText = 'Cancel',
+}) => {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title={title}>
+      <p className="mb-4 text-teal-100">{message}</p>
+      <div className="flex justify-end space-x-2">
+        <FormButton variant="secondary" onClick={onClose}>
+          {cancelText}
+        </FormButton>
+        <FormButton
+          variant="danger"
+          onClick={() => {
+            onConfirm();
+            onClose();
+          }}
+        >
+          {confirmText}
+        </FormButton>
+      </div>
+    </Modal>
+  );
+};
+
+export default ConfirmationModal;


### PR DESCRIPTION
## Summary
- add a generic `ConfirmationModal` component
- use `ConfirmationModal` when deleting vendors, guests, budget items and checklist tasks

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6872ca063ab08327b0dce46573805cba