### PR TITLE
Handle hook errors with user alerts

### DIFF
--- a/src/app/budget/page.tsx
+++ b/src/app/budget/page.tsx
@@ -6,6 +6,7 @@ import { useBudget } from '@/lib/api';
 import { IBudgetItem } from '@/models/BudgetItem';
 import { BudgetItemModal } from '@/components/modals';
 import ConfirmationModal from '@/components/ConfirmationModal';
+import Alert from '@/components/Alert';
 
 const BudgetPage = () => {
   // Define a type for budget items with MongoDB _id
@@ -29,6 +30,7 @@ const BudgetPage = () => {
     BudgetItemWithId | undefined
   >(undefined);
   const [itemToDelete, setItemToDelete] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
   const handleBudgetItemSubmit = async (
     budgetItemData: Partial<IBudgetItem>,
   ) => {
@@ -41,9 +43,12 @@ const BudgetPage = () => {
         await addBudgetItem(budgetItemData);
       }
       setIsModalOpen(false);
+      setActionError(null);
     } catch (error) {
       console.error('Error submitting budget item:', error);
-      // You could set an error state here to show to the user
+      setActionError(
+        error instanceof Error ? error.message : 'An unknown error occurred',
+      );
     }
   };
 
@@ -151,6 +156,9 @@ const BudgetPage = () => {
   return (
     <Layout>
       <div className="space-y-6">
+        {actionError && (
+          <Alert message={actionError} onClose={() => setActionError(null)} />
+        )}
         <div className="flex justify-between items-center p-4 bg-gradient-to-b from-teal-900 to-teal-700 rounded-lg shadow-sm mb-6 border border-teal-600">
           <h1 className="text-3xl font-bold text-white">Budget Tracking</h1>
           <button
@@ -212,9 +220,19 @@ const BudgetPage = () => {
         <ConfirmationModal
           isOpen={itemToDelete !== null}
           onClose={() => setItemToDelete(null)}
-          onConfirm={() => {
+          onConfirm={async () => {
             if (itemToDelete) {
-              deleteBudgetItem(itemToDelete);
+              try {
+                await deleteBudgetItem(itemToDelete);
+                setActionError(null);
+              } catch (err) {
+                console.error('Error deleting budget item:', err);
+                setActionError(
+                  err instanceof Error
+                    ? err.message
+                    : 'An unknown error occurred',
+                );
+              }
             }
           }}
           title="Delete Budget Item"

--- a/src/app/checklist/page.tsx
+++ b/src/app/checklist/page.tsx
@@ -7,6 +7,7 @@ import { IChecklist } from '@/models/ChecklistItem';
 import { ChecklistTaskModal } from '@/components/modals';
 import ConfirmationModal from '@/components/ConfirmationModal';
 import { useSession } from 'next-auth/react';
+import Alert from '@/components/Alert';
 
 // Define a local interface that modifies IChecklist to have _id as optional
 export interface ChecklistItemWithId {
@@ -45,6 +46,7 @@ const ChecklistPage = () => {
     ChecklistItemWithId | undefined
   >(undefined);
   const [taskToDelete, setTaskToDelete] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
 
   // Helper function to determine if a task was assigned to the current user
   const isAssignedToMe = (task: ChecklistItemWithId) => {
@@ -66,9 +68,12 @@ const ChecklistPage = () => {
         await addTask(taskData);
       }
       setIsModalOpen(false);
+      setActionError(null);
     } catch (error) {
       console.error('Error submitting task:', error);
-      // You could set an error state here to show to the user
+      setActionError(
+        error instanceof Error ? error.message : 'An unknown error occurred',
+      );
     }
   };
 
@@ -76,6 +81,12 @@ const ChecklistPage = () => {
     if (!taskToDelete) return;
     try {
       await deleteTask(taskToDelete);
+      setActionError(null);
+    } catch (err) {
+      console.error('Error deleting task:', err);
+      setActionError(
+        err instanceof Error ? err.message : 'An unknown error occurred',
+      );
     } finally {
       setTaskToDelete(null);
     }
@@ -83,6 +94,9 @@ const ChecklistPage = () => {
   return (
     <Layout>
       <div className="space-y-6">
+        {actionError && (
+          <Alert message={actionError} onClose={() => setActionError(null)} />
+        )}
         <div className="flex justify-between items-center p-5 bg-gradient-to-b from-teal-900 to-teal-700 rounded-xl shadow-sm mb-6 border border-teal-600">
           <div>
             <h1 className="text-3xl font-bold text-white">Wedding Checklist</h1>
@@ -329,12 +343,25 @@ const ChecklistPage = () => {
                                   <button
                                     className="bg-teal-600 hover:bg-teal-500 text-teal-100 p-1.5 rounded-full text-xs transition-all transform hover:scale-110 hover:shadow-sm border border-teal-500"
                                     aria-label="Mark as complete"
-                                    onClick={() => {
+                                    onClick={async () => {
                                       if (task._id) {
-                                        updateTask(task._id, {
-                                          ...task,
-                                          completed: true,
-                                        });
+                                        try {
+                                          await updateTask(task._id, {
+                                            ...task,
+                                            completed: true,
+                                          });
+                                          setActionError(null);
+                                        } catch (err) {
+                                          console.error(
+                                            'Error updating task:',
+                                            err,
+                                          );
+                                          setActionError(
+                                            err instanceof Error
+                                              ? err.message
+                                              : 'An unknown error occurred',
+                                          );
+                                        }
                                       }
                                     }}
                                   >
@@ -374,7 +401,9 @@ const ChecklistPage = () => {
                                       <button
                                         className="bg-red-700 hover:bg-red-600 text-red-100 p-1.5 rounded-full text-xs transition-all transform hover:scale-110 hover:shadow-sm border border-red-500"
                                         aria-label="Delete task"
-                                        onClick={() => setTaskToDelete(task._id ?? null)}
+                                        onClick={() =>
+                                          setTaskToDelete(task._id ?? null)
+                                        }
                                       >
                                         <svg
                                           xmlns="http://www.w3.org/2000/svg"
@@ -525,7 +554,9 @@ const ChecklistPage = () => {
                               <button
                                 className="bg-red-700 hover:bg-red-600 text-red-100 p-1.5 rounded-full text-xs transition-all transform hover:scale-110 hover:shadow-sm border border-red-500"
                                 aria-label="Delete task"
-                                onClick={() => setTaskToDelete(task._id ?? null)}
+                                onClick={() =>
+                                  setTaskToDelete(task._id ?? null)
+                                }
                               >
                                 <svg
                                   xmlns="http://www.w3.org/2000/svg"
@@ -704,7 +735,9 @@ const ChecklistPage = () => {
                                     <button
                                       className="bg-gray-300 hover:bg-gray-400 text-gray-600 p-1.5 rounded-full text-xs transition-all"
                                       aria-label="Delete task"
-                                      onClick={() => setTaskToDelete(task._id ?? null)}
+                                      onClick={() =>
+                                        setTaskToDelete(task._id ?? null)
+                                      }
                                     >
                                       <svg
                                         xmlns="http://www.w3.org/2000/svg"

--- a/src/app/guests/page.tsx
+++ b/src/app/guests/page.tsx
@@ -7,6 +7,7 @@ import { useGuests } from '@/lib/api';
 import { GuestModal } from '@/components/modals';
 import ConfirmationModal from '@/components/ConfirmationModal';
 import { IGuest } from '@/models/Guest';
+import Alert from '@/components/Alert';
 
 // RSVP Status Badge component
 const RsvpBadge = ({ status }: { status: string }) => {
@@ -42,6 +43,7 @@ const GuestsPage = () => {
   );
   const [isDeleting, setIsDeleting] = useState<string | null>(null);
   const [guestToDelete, setGuestToDelete] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
 
   const handleGuestSubmit = async (guestData: Partial<IGuest>) => {
     try {
@@ -59,9 +61,12 @@ const GuestsPage = () => {
         logger.info('Guest added successfully');
       }
       setIsModalOpen(false);
+      setActionError(null);
     } catch (error) {
       console.error('Error handling guest submission:', error);
-      // You could set an error state here to show to the user
+      setActionError(
+        error instanceof Error ? error.message : 'An unknown error occurred',
+      );
     }
   };
   const handleDeleteGuest = (id?: string) => {
@@ -77,6 +82,9 @@ const GuestsPage = () => {
       logger.info('Guest deleted successfully');
     } catch (error) {
       console.error('Error deleting guest:', error);
+      setActionError(
+        error instanceof Error ? error.message : 'An unknown error occurred',
+      );
     } finally {
       setIsDeleting(null);
       setGuestToDelete(null);
@@ -321,6 +329,9 @@ const GuestsPage = () => {
   return (
     <Layout>
       <div className="space-y-6">
+        {actionError && (
+          <Alert message={actionError} onClose={() => setActionError(null)} />
+        )}
         <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
           <div>
             <h1 className="text-3xl font-bold text-gray-800">

--- a/src/app/vendors/page.tsx
+++ b/src/app/vendors/page.tsx
@@ -6,6 +6,7 @@ import { IVendor } from '@/models/Vendor';
 import { VendorModal } from '@/components/modals';
 import ConfirmationModal from '@/components/ConfirmationModal';
 import { useVendors } from '@/lib/api';
+import Alert from '@/components/Alert';
 
 const VendorsPage = () => {
   const { vendors, isLoading, error, addVendor, updateVendor, deleteVendor } =
@@ -15,6 +16,7 @@ const VendorsPage = () => {
     undefined,
   );
   const [vendorToDelete, setVendorToDelete] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
   // Define a type for vendors with MongoDB _id
   type VendorWithId = IVendor & {
     _id: string;
@@ -30,9 +32,12 @@ const VendorsPage = () => {
         await addVendor(vendorData);
       }
       setIsModalOpen(false);
+      setActionError(null);
     } catch (error) {
       console.error('Error submitting vendor:', error);
-      // You could set an error state here to show to the user
+      setActionError(
+        error instanceof Error ? error.message : 'An unknown error occurred',
+      );
     }
   };
 
@@ -248,7 +253,9 @@ const VendorsPage = () => {
               </button>
               <button
                 className="bg-teal-800 hover:bg-teal-700 text-teal-100 px-3 py-2 rounded-md text-sm transition-colors flex-1 flex items-center justify-center border border-teal-500"
-                onClick={() => setVendorToDelete(vendor._id?.toString() || null)}
+                onClick={() =>
+                  setVendorToDelete(vendor._id?.toString() || null)
+                }
               >
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
@@ -274,6 +281,9 @@ const VendorsPage = () => {
   return (
     <Layout>
       <div className="space-y-6">
+        {actionError && (
+          <Alert message={actionError} onClose={() => setActionError(null)} />
+        )}
         <div className="flex justify-between items-center p-5 bg-gradient-to-b from-teal-900 to-teal-700 rounded-xl shadow-sm mb-6 border border-teal-600">
           <h1 className="text-3xl font-bold text-white">Vendor Management</h1>
           <button
@@ -310,9 +320,19 @@ const VendorsPage = () => {
         <ConfirmationModal
           isOpen={vendorToDelete !== null}
           onClose={() => setVendorToDelete(null)}
-          onConfirm={() => {
+          onConfirm={async () => {
             if (vendorToDelete) {
-              deleteVendor(vendorToDelete);
+              try {
+                await deleteVendor(vendorToDelete);
+                setActionError(null);
+              } catch (err) {
+                console.error('Error deleting vendor:', err);
+                setActionError(
+                  err instanceof Error
+                    ? err.message
+                    : 'An unknown error occurred',
+                );
+              }
             }
           }}
           title="Delete Vendor"

--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+interface AlertProps {
+  message: string;
+  onClose?: () => void;
+}
+
+const Alert: React.FC<AlertProps> = ({ message, onClose }) => (
+  <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-2 rounded relative">
+    <span className="block sm:inline">{message}</span>
+    {onClose && (
+      <button
+        onClick={onClose}
+        className="absolute top-0 bottom-0 right-0 px-4 py-2"
+        aria-label="Close alert"
+      >
+        <svg className="fill-current h-4 w-4" role="img" viewBox="0 0 20 20">
+          <path d="M14.348 5.652a.5.5 0 10-.707-.708L10 8.586 6.359 4.944a.5.5 0 10-.707.708L9.293 9.293l-3.641 3.651a.5.5 0 00.707.707L10 9.999l3.641 3.651a.5.5 0 00.707-.707L10.707 9.293l3.641-3.641z" />
+        </svg>
+      </button>
+    )}
+  </div>
+);
+
+export default Alert;


### PR DESCRIPTION
## Summary
- add a simple `Alert` component for displaying errors
- capture errors from add/update/delete hooks on budget, vendor, guest and checklist pages
- surface errors with inline alerts on these pages

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6872d1fe64b48327b4b3e93ee03e0e9e